### PR TITLE
no need to reset 'cpo' in Vim9 script

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -21,10 +21,6 @@ if v:version < 802 || !has('patch-8.2.1665')
   finish
 endif
 
-# Line continuation used here
-let s:cpo_save = &cpo
-set cpo&vim
-
 let s:filelist: list<string> = []
 let s:popup_text: list<string> = []
 let s:filter_text: string = ''
@@ -224,8 +220,5 @@ def fileselect#toggle()
     s:popup_winid->popup_close(-2)
   endif
 enddef
-
-# restore 'cpo'
-&cpo = s:cpo_save
 
 # vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
In Vim9 script, it is no longer needed to temporarily reset the `'cpoptions'` option, because that's already done by `:vim9script`.  See [`:h :vim9script`](https://vimhelp.org/vim9.txt.html#:vim9script).

> A side effect of `:vim9script` is that the 'cpoptions' option is set to the
> Vim default value, like with: >
>         :set cpo&vim
> One of the effects is that |line-continuation| is always enabled.
> The original value of 'cpoptions' is restored at the end of the script.

Thank you for writing this plugin.
