### PR TITLE
refactor :let into :var

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -22,13 +22,13 @@ if v:version < 802 || !has('patch-8.2.1665')
 endif
 
 # Line continuation used here
-let s:cpo_save = &cpo
+var s:cpo_save = &cpo
 set cpo&vim
 
-let s:filelist: list<string> = []
-let s:popup_text: list<string> = []
-let s:filter_text: string = ''
-let s:popup_winid: number = -1
+var s:filelist: list<string> = []
+var s:popup_text: list<string> = []
+var s:filter_text: string = ''
+var s:popup_winid: number = -1
 
 # Edit the file selected from the popup menu
 def s:editFile(id: number, result: number)
@@ -39,8 +39,8 @@ def s:editFile(id: number, result: number)
   endif
   try
     # if the selected file is already present in a window, then jump to it
-    let fname: string = s:popup_text[result - 1]
-    let winList: list<number> = fname->bufnr()->win_findbuf()
+    var fname: string = s:popup_text[result - 1]
+    var winList: list<number> = fname->bufnr()->win_findbuf()
     if winList->len() == 0
       # Not present in any window
       if &modified || &buftype != ''
@@ -61,11 +61,11 @@ enddef
 # Convert each file name in the items List into <filename> (<dirname>) format.
 # Make sure the popup does't occupy the entire screen by reducing the width.
 def s:makeMenuName(items: list<string>)
-  let maxwidth: number = s:popup_winid->popup_getpos().core_width
+  var maxwidth: number = s:popup_winid->popup_getpos().core_width
 
-  let filename: string
-  let dirname: string
-  let flen: number
+  var filename: string
+  var dirname: string
+  var flen: number
   for i in items->len()->range()
     filename = items[i]->fnamemodify(':t')
     flen = filename->len()
@@ -75,7 +75,7 @@ def s:makeMenuName(items: list<string>)
       # keep the full file name and reduce directory name length
       # keep some characters at the beginning and end (equally).
       # 6 spaces are used for "..." and " ()"
-      let dirsz = (maxwidth - flen - 6) / 2
+      var dirsz = (maxwidth - flen - 6) / 2
       dirname = dirname[:dirsz] .. '...' .. dirname[-dirsz:]
     endif
     items[i] = filename
@@ -88,8 +88,8 @@ enddef
 # Handle the keys typed in the popup menu.
 # Narrow down the displayed names based on the keys typed so far.
 def s:filterNames(id: number, key: string): number
-  let update_popup: number = 0
-  let key_handled: number = 0
+  var update_popup: number = 0
+  var key_handled: number = 0
 
   if key == "\<BS>"
     # Erase one character from the filter text
@@ -110,7 +110,7 @@ def s:filterNames(id: number, key: string): number
         \ || key == "<C-Home>"
         \ || key == "<C-End>"
     # scroll the popup window
-    let cmd: string = 'normal! ' .. key
+    var cmd: string = 'normal! ' .. key
     cmd->win_execute(s:popup_winid)
     key_handled = 1
   elseif key == "\<Up>" || key == "\<Down>"
@@ -127,9 +127,9 @@ def s:filterNames(id: number, key: string): number
     # Update the popup with the new list of file names
 
     # Keep the cursor at the current item
-    let prevSelName: string = ''
+    var prevSelName: string = ''
     if s:popup_text->len() > 0
-      let curLine: number = line('.', s:popup_winid)
+      var curLine: number = line('.', s:popup_winid)
       prevSelName = s:popup_text[curLine - 1]
     endif
 
@@ -138,15 +138,15 @@ def s:filterNames(id: number, key: string): number
     else
       s:popup_text = s:filelist
     endif
-    let items: list<string> = s:popup_text->copy()
+    var items: list<string> = s:popup_text->copy()
     s:makeMenuName(items)
     id->popup_settext(items)
     echo 'File: ' .. s:filter_text
 
     # Select the previously selected entry. If not present, select first entry
-    let idx: number = s:popup_text->index(prevSelName)
+    var idx: number = s:popup_text->index(prevSelName)
     idx = idx == -1 ? 1 : idx + 1
-    let cmd: string = 'cursor(' .. idx .. ', 1)'
+    var cmd: string = 'cursor(' .. idx .. ', 1)'
     cmd->win_execute(s:popup_winid)
   endif
 
@@ -161,15 +161,15 @@ def fileselect#showMenu(pat_arg: string)
   # Get the list of file names to display.
 
   # Default pattern to get all the filenames in the current directory tree.
-  let pat: string = '**/*'
+  var pat: string = '**/*'
   if pat_arg != ''
     # use the user specified pattern
     pat = '**/*' .. pat_arg .. '*'
   endif
 
-  let save_wildignore = &wildignore
+  var save_wildignore = &wildignore
   set wildignore=*.o,*.obj,*.swp,*.bak,*.~
-  let l: list<string> = pat->glob(0, 1)
+  var l: list<string> = pat->glob(0, 1)
   &wildignore = save_wildignore
   if l->empty()
     echohl Error | echo "No files found" | echohl None
@@ -188,8 +188,8 @@ def fileselect#showMenu(pat_arg: string)
   s:filter_text = ''
 
   # Create the popup menu
-  let lnum = &lines - &cmdheight - 2 - 10
-  let popupAttr = #{
+  var lnum = &lines - &cmdheight - 2 - 10
+  var popupAttr = #{
       title: 'File Selector',
       wrap: 0,
       pos: 'topleft',
@@ -208,7 +208,7 @@ def fileselect#showMenu(pat_arg: string)
 
   # Populate the popup menu
   # Split the names into file name and directory path.
-  let items: list<string> = s:popup_text->copy()
+  var items: list<string> = s:popup_text->copy()
   s:makeMenuName(items)
   s:popup_winid->popup_settext(items)
   echo 'File: '


### PR DESCRIPTION
Since [8.2.1788](https://github.com/vim/vim/releases/tag/v8.2.1788), we can no longer use `:let` to assign a variable.  So I refactored all the `:let`s into `:var`s.  Alternatively, we could also set `v:disallow_let` to 0.  But I thought using `:var` would be better, because that's what is used everywhere at `:h vim9`.

The rationale behind this new assignment command is given at [`:h vim9-rationale`](https://vimhelp.org/vim9.txt.html#vim9-rationale):

> Legacy Vim script uses `:let` for every assignment, while in Vim9 declarations
> are used.  That is different, thus it's good to use a different command:
> `:var`.  This is used in many languages.  The semantics might be slightly
> different, but it's easily recognized as a declaration.


