### PR TITLE
remove script-local scope

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -22,16 +22,16 @@ if v:version < 802 || !has('patch-8.2.1665')
 endif
 
 # Line continuation used here
-let s:cpo_save = &cpo
+let cpo_save = &cpo
 set cpo&vim
 
-let s:filelist: list<string> = []
-let s:popup_text: list<string> = []
-let s:filter_text: string = ''
-let s:popup_winid: number = -1
+let filelist: list<string> = []
+let popup_text: list<string> = []
+let filter_text: string = ''
+let popup_winid: number = -1
 
 # Edit the file selected from the popup menu
-def s:editFile(id: number, result: number)
+def EditFile(id: number, result: number)
   # clear the message displayed at the command-line
   echo ''
   if result <= 0
@@ -39,16 +39,16 @@ def s:editFile(id: number, result: number)
   endif
   try
     # if the selected file is already present in a window, then jump to it
-    let fname: string = s:popup_text[result - 1]
+    let fname: string = popup_text[result - 1]
     let winList: list<number> = fname->bufnr()->win_findbuf()
     if winList->len() == 0
       # Not present in any window
       if &modified || &buftype != ''
         # the current buffer is modified or is not a normal buffer, then open
         # the file in a new window
-        exe "split " .. s:popup_text[result - 1]
+        exe "split " .. popup_text[result - 1]
       else
-        exe "confirm edit " .. s:popup_text[result - 1]
+        exe "confirm edit " .. popup_text[result - 1]
       endif
     else
       winList[0]->win_gotoid()
@@ -60,8 +60,8 @@ enddef
 
 # Convert each file name in the items List into <filename> (<dirname>) format.
 # Make sure the popup does't occupy the entire screen by reducing the width.
-def s:makeMenuName(items: list<string>)
-  let maxwidth: number = s:popup_winid->popup_getpos().core_width
+def MakeMenuName(items: list<string>)
+  let maxwidth: number = popup_winid->popup_getpos().core_width
 
   let filename: string
   let dirname: string
@@ -87,20 +87,20 @@ enddef
 
 # Handle the keys typed in the popup menu.
 # Narrow down the displayed names based on the keys typed so far.
-def s:filterNames(id: number, key: string): number
+def FilterNames(id: number, key: string): number
   let update_popup: number = 0
   let key_handled: number = 0
 
   if key == "\<BS>"
     # Erase one character from the filter text
-    if s:filter_text->len() >= 1
-      s:filter_text = s:filter_text[:-2]
+    if filter_text->len() >= 1
+      filter_text = filter_text[:-2]
       update_popup = 1
     endif
     key_handled = 1
   elseif key == "\<C-U>"
     # clear the filter text
-    s:filter_text = ''
+    filter_text = ''
     update_popup = 1
     key_handled = 1
   elseif key == "\<C-F>"
@@ -111,14 +111,14 @@ def s:filterNames(id: number, key: string): number
         \ || key == "<C-End>"
     # scroll the popup window
     let cmd: string = 'normal! ' .. key
-    cmd->win_execute(s:popup_winid)
+    cmd->win_execute(popup_winid)
     key_handled = 1
   elseif key == "\<Up>" || key == "\<Down>"
     # Use native Vim handling for these keys
     key_handled = 0
   elseif key =~ '^\f$' || key == "\<Space>"
     # Filter the names based on the typed key and keys typed before
-    s:filter_text ..= key
+    filter_text ..= key
     update_popup = 1
     key_handled = 1
   endif
@@ -128,26 +128,26 @@ def s:filterNames(id: number, key: string): number
 
     # Keep the cursor at the current item
     let prevSelName: string = ''
-    if s:popup_text->len() > 0
-      let curLine: number = line('.', s:popup_winid)
-      prevSelName = s:popup_text[curLine - 1]
+    if popup_text->len() > 0
+      let curLine: number = line('.', popup_winid)
+      prevSelName = popup_text[curLine - 1]
     endif
 
-    if s:filter_text != ''
-      s:popup_text = s:filelist->matchfuzzy(s:filter_text)
+    if filter_text != ''
+      popup_text = filelist->matchfuzzy(filter_text)
     else
-      s:popup_text = s:filelist
+      popup_text = filelist
     endif
-    let items: list<string> = s:popup_text->copy()
-    s:makeMenuName(items)
+    let items: list<string> = popup_text->copy()
+    MakeMenuName(items)
     id->popup_settext(items)
-    echo 'File: ' .. s:filter_text
+    echo 'File: ' .. filter_text
 
     # Select the previously selected entry. If not present, select first entry
-    let idx: number = s:popup_text->index(prevSelName)
+    let idx: number = popup_text->index(prevSelName)
     idx = idx == -1 ? 1 : idx + 1
     let cmd: string = 'cursor(' .. idx .. ', 1)'
-    cmd->win_execute(s:popup_winid)
+    cmd->win_execute(popup_winid)
   endif
 
   if key_handled
@@ -181,11 +181,11 @@ def fileselect#showMenu(pat_arg: string)
 
   # Expand the file paths and reduce it relative to the home and current
   # directories
-  s:filelist = l->map('fnamemodify(v:val, ":p:~:.")')
+  filelist = l->map('fnamemodify(v:val, ":p:~:.")')
 
   # Save it for later use
-  s:popup_text = s:filelist->copy()
-  s:filter_text = ''
+  popup_text = filelist->copy()
+  filter_text = ''
 
   # Create the popup menu
   let lnum = &lines - &cmdheight - 2 - 10
@@ -201,31 +201,31 @@ def fileselect#showMenu(pat_arg: string)
       maxwidth: 60,
       fixed: 1,
       close: "button",
-      filter: function('s:filterNames'),
-      callback: function('s:editFile')
+      filter: FilterNames,
+      callback: EditFile
   }
-  s:popup_winid = popup_menu([], popupAttr)
+  popup_winid = popup_menu([], popupAttr)
 
   # Populate the popup menu
   # Split the names into file name and directory path.
-  let items: list<string> = s:popup_text->copy()
-  s:makeMenuName(items)
-  s:popup_winid->popup_settext(items)
+  let items: list<string> = popup_text->copy()
+  MakeMenuName(items)
+  popup_winid->popup_settext(items)
   echo 'File: '
 enddef
 
 # Toggle (open or close) the fileselect popup menu
 def fileselect#toggle()
-  if s:popup_winid->popup_getoptions()->empty()
+  if popup_winid->popup_getoptions()->empty()
     # open the file select popup
     fileselect#showMenu('')
   else
     # popup window is present. close it.
-    s:popup_winid->popup_close(-2)
+    popup_winid->popup_close(-2)
   endif
 enddef
 
 # restore 'cpo'
-&cpo = s:cpo_save
+&cpo = cpo_save
 
 # vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
I think we can remove the script-local scope all the time.  There might be some edge cases where it's needed (and even then I wonder whether it's a Vim bug), but not in the current plugin.

To be able to get rid of `s:` in the popup options related to the filter and the callback, I also had to remove `function()`, which is allowed and documented somewhere at `:h vim9`

> Omitting function()
>
> A user defined function can be used as a function reference in an expression
> without `function()`. The argument types and return type will then be checked.
> The function must already have been defined. >
>
>         var Funcref = MyFunction
>
> When using `function()` the resulting type is "func", a function with any
> number of arguments and any return type.  The function can be defined later.
