### PR TITLE
lambdas are faster than eval strings in :def functions

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -177,11 +177,11 @@ def fileselect#showMenu(pat_arg: string)
   endif
 
   # Remove all the directory names
-  l->filter('!isdirectory(v:val)')
+  l->filter({_, v -> !isdirectory(v)})
 
   # Expand the file paths and reduce it relative to the home and current
   # directories
-  s:filelist = l->map('fnamemodify(v:val, ":p:~:.")')
+  s:filelist = l->map({_, v -> fnamemodify(v, ':p:~:.')})
 
   # Save it for later use
   s:popup_text = s:filelist->copy()


### PR DESCRIPTION
As the title suggests, lambdas are faster than eval strings inside a `:def` function.  I think that's because they're compiled, while eval strings are not.
