### PR TITLE
fix a few Vim keycodes

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -104,11 +104,11 @@ def s:filterNames(id: number, key: string): number
     update_popup = 1
     key_handled = 1
   elseif key == "\<C-F>"
-        \ || key == "\<C-B>"
-        \ || key == "<PageUp>"
-        \ || key == "<PageDown>"
-        \ || key == "<C-Home>"
-        \ || key == "<C-End>"
+        || key == "\<C-B>"
+        || key == "\<PageUp>"
+        || key == "\<PageDown>"
+        || key == "\<C-Home>"
+        || key == "\<C-End>"
     # scroll the popup window
     let cmd: string = 'normal! ' .. key
     cmd->win_execute(s:popup_winid)


### PR DESCRIPTION
A few Vim keycodes were missing a backslash which is necessary for the translation.  I also removed some backslashes used as line continuations, which are no longer necessary in a Vim9 script.
