### PR TITLE
fix <expr> mapping

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -215,7 +215,7 @@ def fileselect#showMenu(pat_arg: string)
 enddef
 
 # Toggle (open or close) the fileselect popup menu
-def fileselect#toggle()
+def fileselect#toggle(): string
   if s:popup_winid->popup_getoptions()->empty()
     # open the file select popup
     fileselect#showMenu('')
@@ -223,6 +223,7 @@ def fileselect#toggle()
     # popup window is present. close it.
     s:popup_winid->popup_close(-2)
   endif
+  return "\<Ignore>"
 enddef
 
 # restore 'cpo'


### PR DESCRIPTION
The current [`<expr>` mapping](https://github.com/yegappan/fileselect/blob/d0390f0d13485343ce545e16d98d5d37e67df20c/plugin/fileselect.vim#L27) does not work as expected because [`fileselect#toggle()`](https://github.com/yegappan/fileselect/blob/d0390f0d13485343ce545e16d98d5d37e67df20c/autoload/fileselect.vim#L218) returns the default value 0.  To work as expected, it should return an empty string.  However, even with an empty string, the mapping would suffer from [another bug](https://github.com/vim/vim/issues/7011#issuecomment-699536407).  I think [the solution](https://github.com/vim/vim/issues/7011#issuecomment-702179401) is to make the function return `<Ignore>`.
