### PR TITLE
fix echo when :Fileselect is passed an argument

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -211,7 +211,7 @@ def fileselect#showMenu(pat_arg: string)
   let items: list<string> = s:popup_text->copy()
   s:makeMenuName(items)
   s:popup_winid->popup_settext(items)
-  echo 'File: '
+  echo 'File: ' .. pat_arg
 enddef
 
 # Toggle (open or close) the fileselect popup menu


### PR DESCRIPTION
Currently, if we run `:Fileselect` with a pattern, it is not echo'ed on the command-line.  This PR simply adds the pattern to the last `:echo` command.
