### PR TITLE
use "ErrorMsg" highlight group instead of "Error"

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -32,7 +32,7 @@ var refreshTimer: number = 0
 var ignoreFilePat: string = '\%(^\..\+\)\|\%(^.\+\.o\)\|\%(^.\+\.obj\)'
 
 def Err(msg: string)
-  echohl Error
+  echohl ErrorMsg
   echo msg
   echohl None
 enddef


### PR DESCRIPTION
"Error" is not defined by default (i.e. if `syntax on` has not been run), while "ErrorMsg" is.  "ErrorMsg" is listed at `:h highlight-default`, while "Error" is not.

In particular, if we start Vim like this:

    vim -Nu NORC

"Error" does not exist, while "ErrorMsg" does.
