### PR TITLE
honor 'wildignore' when filtering out files

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -28,8 +28,16 @@ var fileList: list<string> = []
 var filterStr: string = ''
 var dirQueue: list<string> = []
 var refreshTimer: number = 0
-# File names matching this pattern are ignored
-var ignoreFilePat: string = '\%(^\..\+\)\|\%(^.\+\.o\)\|\%(^.\+\.obj\)'
+# Ignore hidden files
+var ignoreFilePat: string = '\%(^\..\+\)'
+  # and any file matching 'wildignore'
+  .. (&wildignore != ''
+    ? '\|' .. &wildignore
+    # split before any comma which is not preceded by an odd number of backslashes
+    ->split('\%(\\\@<!\\\%(\\\\\)*\\\@!\)\@<!,')
+    # convert globs into regex
+    ->map('glob2regpat(v:val)')->join('\|')
+    : '')
 
 def Err(msg: string)
   echohl Error


### PR DESCRIPTION
This PR tries to make the plugin honor the `'wildignore'` option.

Note that the `map()` invocation uses an eval string instead of a lambda.  This is because, at the script level, an eval string is still faster, just like in Vim script legacy.  It's only inside a `:def` function that a lambda gets faster thanks to the compilation.
