### PR TITLE
Use new lambda syntax.  Respect whitespace rule in sublists.

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -54,9 +54,9 @@ def EditFile(id: number, result: number): void
       if &modified || &buftype != ''
         # the current buffer is modified or is not a normal buffer, then open
         # the file in a new window
-        exe "split " .. popupText[result - 1]
+        exe 'split ' .. popupText[result - 1]
       else
-        exe "confirm edit " .. popupText[result - 1]
+        exe 'confirm edit ' .. popupText[result - 1]
       endif
     else
       winList[0]->win_gotoid()
@@ -84,7 +84,7 @@ def MakeMenuName(items: list<string>): void
       # keep some characters at the beginning and end (equally).
       # 6 spaces are used for "..." and " ()"
       var dirsz = (maxwidth - flen - 6) / 2
-      dirname = dirname[:dirsz] .. '...' .. dirname[-dirsz:]
+      dirname = dirname[: dirsz] .. '...' .. dirname[-dirsz :]
     endif
     items[i] = filename
     if dirname != '.'
@@ -109,7 +109,7 @@ def FilterNames(id: number, key: string): bool
   if key == "\<BS>" || key == "\<C-H>"
     # Erase one character from the filter text
     if filterStr->len() >= 1
-      filterStr = filterStr[:-2]
+      filterStr = filterStr[: -2]
       update_popup = 1
     endif
     key_handled = 1
@@ -161,7 +161,7 @@ def FilterNames(id: number, key: string): bool
   endif
 
   if key_handled
-    return v:true
+    return true
   endif
 
   return id->popup_filter_menu(key)
@@ -191,13 +191,13 @@ def UpdatePopup(): void
   var text: list<dict<any>>
   if len(matchpos) > 0
     text = items
-       ->map({i, v -> {
+       ->map((i: number, v: string): dict<any> => ({
          text: v,
          props: map(matchpos[i],
-                    {_, w -> {col: w + 1, length: 1, type: 'fileselect'}})
-       }})
+                    (_, w: number): dict<any> => ({col: w + 1, length: 1, type: 'fileselect'}))
+       }))
   else
-    text = items->map({_, v -> {text: v}})
+    text = items->map((_, v: string): dict<string> => ({text: v}))
   endif
   popupID->popup_settext(text)
 enddef
@@ -253,13 +253,13 @@ def ProcessDir(dir: string): void
   endwhile
 
   if dirQueue->len() == 0 && fileList->len() == 0
-    Err("No files found")
+    Err('No files found')
     return
   endif
 
   # Expand the file paths and reduce it relative to the home and current
   # directories
-  fileList = fileList->map({_, v -> fnamemodify(v, ':p:~:.')})
+  fileList = fileList->map((_, v: string): string => fnamemodify(v, ':p:~:.'))
 
   UpdatePopup()
   if dirQueue->len() > 0
@@ -303,14 +303,14 @@ def fileselect#showMenu(dir_arg: string): void
     # shorten the directory name relative to the current directory
     start_dir = start_dir->fnamemodify(':p:.')
   endif
-  if start_dir[-1:] == '/'
+  if start_dir[-1 :] == '/'
     # trim the / at the end of the name
-    start_dir = start_dir[:-2]
+    start_dir = start_dir[: -2]
   endif
 
   # make sure a valid directory is specified
   if start_dir->getftype() != 'dir'
-    Err("Error: Invalid directory " .. start_dir)
+    Err('Error: Invalid directory ' .. start_dir)
     return
   endif
 
@@ -319,7 +319,7 @@ def fileselect#showMenu(dir_arg: string): void
     popupTitle = '[' .. start_dir .. ']'
   else
     # trim the title and show the trailing characters
-    popupTitle = '[...' .. start_dir[-37:] .. ']'
+    popupTitle = '[...' .. start_dir[-37 :] .. ']'
   endif
 
   # Create the popup menu
@@ -335,13 +335,13 @@ def fileselect#showMenu(dir_arg: string): void
       maxheight: 10,
       maxwidth: 60,
       fixed: 1,
-      close: "button",
+      close: 'button',
       filter: FilterNames,
       callback: EditFile
   }
   popupID = popup_menu([], popupAttr)
-  prop_type_add('fileselect', {'bufnr': popupID->winbufnr(),
-                                highlight: 'Title'})
+  prop_type_add('fileselect', {bufnr: popupID->winbufnr(),
+                               highlight: 'Title'})
 
   # Get the list of file names to display.
   GetFiles(start_dir)


### PR DESCRIPTION
This PR updates the plugin so that it works on newer Vim versions.

Since [8.2.2257](https://github.com/vim/vim/releases/tag/v8.2.2257), we can no longer use the old syntax for lambdas:

    {args -> expr}

We must use the new one:

    (args) => expr

---

Since [8.2.2250](https://github.com/vim/vim/releases/tag/v8.2.2250), we must add whitespace around a colon in a sublist.  See [this issue](https://github.com/vim/vim/issues/7409) for the rationale.

So, this no longer works:

    var l = [1, 2, 3, 4, 5]
    echo l[1:3]
           ^^^
            ✘

Instead, we must write:

    echo l[1 : 3]
            ^^^
             ✔

Note that there is still no need to write a whitespace between the colon and a bracket.  So, these work:

    echo l[: 3]
          ^^
          ✔

    echo l[1 :]
             ^^
             ✔

---

I also added some type checking for the used arguments of the lambdas, and for their returned value.  This is possible since [8.2.1956](https://github.com/vim/vim/releases/tag/v8.2.1956).

I haven't type checked the *unused* arguments of the lambdas (`_`), but maybe you'll want to do it.

---

I replaced double quotes with single quotes whenever possible; to gain in consistency, and to code defensively (i.e. it suppresses special characters translation which could appear in a future refactoring).

---

I removed an unnecessary `v:` prefix in a `v:true` value.

---

Finally, I removed unnecessary quotes around a `bufnr` key.  It was necessary in the past, because of a bug which was fixed in [8.2.2200](https://github.com/vim/vim/releases/tag/v8.2.2200).  However, the issue re-appeared in [8.2.2227](https://github.com/vim/vim/releases/tag/v8.2.2227).  The latter issue was fixed in [8.2.2257](https://github.com/vim/vim/releases/tag/v8.2.2257).

Note that 8.2.2257 is not the minimal version for the plugin to work.  A different bug broke the plugin in [8.2.2254](https://github.com/vim/vim/releases/tag/v8.2.2254).  The latter was fixed in [8.2.2261](https://github.com/vim/vim/releases/tag/v8.2.2261).

To summarize, the absolute minimum Vim version required for the plugin to work once the patch is applied should be 8.2.2261.  I tested on 8.2.2269, and it seems to work.

