### PR TITLE
Fix: E1012: Type mismatch error

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -103,7 +103,7 @@ def FilterNames(id: number, key: string): bool
   # timer.
   refreshTimerID->timer_stop()
   if key != "\<Esc>" && dirQueue->len() > 0
-    refreshTimerID = timer_start(1000, TimerCallback)
+    refreshTimerID = timer_start(1'000, TimerCallback)
   endif
 
   if key == "\<BS>" || key == "\<C-H>"
@@ -191,13 +191,13 @@ def UpdatePopup(): void
   var text: list<dict<any>>
   if len(matchpos) > 0
     text = items
-       ->map((i: number, v: string): dict<any> => ({
+       ->mapnew((i: number, v: string): dict<any> => ({
          text: v,
-         props: map(matchpos[i],
+         props: mapnew(matchpos[i],
                     (_, w: number): dict<any> => ({col: w + 1, length: 1, type: 'fileselect'}))
        }))
   else
-    text = items->map((_, v: string): dict<string> => ({text: v}))
+    text = items->mapnew((_, v: string): dict<string> => ({text: v}))
   endif
   popupID->popup_settext(text)
 enddef


### PR DESCRIPTION
Since [8.2.2325](https://github.com/vim/vim/releases/tag/v8.2.2325), `map()` can no longer change the type of the items in a list.  This causes the plugin to raise a type mismatch error when `:Fileselect` is executed:

    E1012: Type mismatch; expected list<dict<any>> but got list<string>

Then another one when we start typing some filtering text:

    E1012: Type mismatch; expected number but got dict<any>

See [here](https://github.com/vim/vim/issues/7655#issuecomment-757874370) for the rationale.

The solution is to use `mapnew()` instead, which is available since [8.2.1969](https://github.com/vim/vim/releases/tag/v8.2.1969).

---

I've also added a single quote in the waiting time of a timer, because I though it could slightly improve the readability.  See [`:h scriptversion-4`](https://vimhelp.org/eval.txt.html#scriptversion-4):

> Also, it is possible to use single quotes inside numbers to make them
>  easier to read:
>          echo 1'000'000
> The quotes must be surrounded by digits.

---

I was tempted to also remove `<C-N>` and `<C-P>` from the popup filter, because these keys are now automatically handled by `popup_filter_menu()` since [8.2.2296](https://github.com/vim/vim/releases/tag/v8.2.2296), but that would have increased the minimum required Vim version for the plugin, which is 8.2.2261 at the moment.  So, I didn't.

Likewise, I was tempted to simplify a string slice to access the last character of a string:
```diff
diff --git a/autoload/fileselect.vim b/autoload/fileselect.vim
index 8d8b49c..6218b36 100644
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -303,7 +303,7 @@ def fileselect#showMenu(dir_arg: string): void
     # shorten the directory name relative to the current directory
     start_dir = start_dir->fnamemodify(':p:.')
   endif
-  if start_dir[-1 :] == '/'
+  if start_dir[-1] == '/'
     # trim the / at the end of the name
     start_dir = start_dir[: -2]
   endif
```
Because since [8.2.2318](https://github.com/vim/vim/releases/tag/v8.2.2318), negative indexes work the same whether they're used in a string slice or a list slice.  But again, that would have increased the minimum required Vim version.  So, I didn't.

