### PR TITLE
support `<mods>`

### DIFF
--- a/autoload/fileselect.vim
+++ b/autoload/fileselect.vim
@@ -38,7 +38,7 @@ def Err(msg: string): void
 enddef
 
 # Edit the file selected from the popup menu
-def EditFile(id: number, result: number): void
+def EditFile(id: number, result: number, mods: string): void
   # clear the message displayed at the command-line
   echo ''
   refreshTimerID->timer_stop()
@@ -54,9 +54,9 @@ def EditFile(id: number, result: number): void
       if &modified || &buftype != ''
         # the current buffer is modified or is not a normal buffer, then open
         # the file in a new window
-        exe 'split ' .. popupText[result - 1]
+        exe mods 'split ' .. popupText[result - 1]
       else
-        exe 'confirm edit ' .. popupText[result - 1]
+        exe 'confirm' mods 'edit ' .. popupText[result - 1]
       endif
     else
       winList[0]->win_gotoid()
@@ -294,7 +294,7 @@ def GetFiles(start_dir: string): void
   ProcessDir(start_dir)
 enddef
 
-def fileselect#showMenu(dir_arg: string): void
+def fileselect#showMenu(dir_arg: string, mods: string): void
   var start_dir: string = dir_arg
   if dir_arg == ''
     # default is current directory
@@ -337,7 +337,7 @@ def fileselect#showMenu(dir_arg: string): void
       fixed: 1,
       close: 'button',
       filter: FilterNames,
-      callback: EditFile
+      callback: (id, result) => EditFile(id, result, mods)
   }
   popupID = popup_menu([], popupAttr)
   prop_type_add('fileselect', {bufnr: popupID->winbufnr(),

--- a/plugin/fileselect.vim
+++ b/plugin/fileselect.vim
@@ -21,7 +21,7 @@ if v:version < 802 || !has('patch-8.2.2261')
 endif
 
 " User command to open the file select popup menu
-command! -nargs=* -complete=dir Fileselect call fileselect#showMenu(<q-args>)
+command! -nargs=* -complete=dir Fileselect call fileselect#showMenu(<q-args>, <q-mods>)
 
 " key mapping to toggle the file select popup menu
 nnoremap <expr> <silent> <Plug>Fileselect_Toggle fileselect#toggle()


### PR DESCRIPTION
This enables things like `:vertical Fileselect` and `:tab Fileselect` to do
the obvious thing (open the selected file vertically/in a new tab).

The mods are applied to the `edit` when re-using the current window, but
in many cases (like the examples above) they have no effect.